### PR TITLE
fix: skip ESA model caching when file exceeds 512 MB (v0.0.31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [`v0.0.31`] - 2026-04-20
+
+### Fixed
+- **App hing op "Stage 2: XML output voor cache: X KB"**: de blocking call `analysis.get_updated_esa_model()` — die het volledige binaire SCIA-modelbestand (`.esa`) van de SCIA-worker downloadt — kon de applicatie onbeperkt laten hangen bij grote modellen. De ESA-download heeft geen groottegrens in het VIKTOR SDK.
+
+  **Oplossing**: nieuw hulpfunctie `_extract_esa_model_with_size_limit` downloadt het ESA-bestand en controleert daarna de grootte. Overschrijdt het bestand de limiet van `MAX_ESA_CACHE_SIZE_MB` (standaard 512 MB), dan worden de bytes direct weggegooid en wordt `None` teruggegeven. Een thread-timeout is niet toegepast: als het RAM-gebruik de omgevingslimiet overschrijdt crasht de worker sowieso en herstart hij automatisch.
+
+  Twee nieuwe constanten in `app/constants/technical.py`:
+  - `ENABLE_ESA_MODEL_CACHING: bool = True` — aan/uit schakelaar voor ESA caching
+  - `MAX_ESA_CACHE_SIZE_MB: int = 512` — maximale toegestane ESA-bestandsgrootte
+
+  De knop "Download ESA Model" blijft werken via de bestaande fallback die de analyse direct opnieuw uitvoert wanneer het ESA-bestand niet in de cache aanwezig is.
+
 ## [`v0.0.30`] - 2026-04-17
 
 ### Changed

--- a/app/bridge/scia_model_builder.py
+++ b/app/bridge/scia_model_builder.py
@@ -1551,6 +1551,55 @@ def _extract_esa_model_for_caching(analysis: SciaAnalysis) -> bytes | None:
     return None
 
 
+def _extract_esa_model_with_size_limit(
+    analysis: SciaAnalysis,
+    max_size_mb: float,
+    progress_prefix: str = "",
+    percentage: int | None = None,
+) -> bytes | None:
+    """
+    Download ESA model from the SCIA worker and discard it if too large.
+
+    A thread timeout is not used because exceeding the environment RAM limit
+    causes the worker to crash and restart anyway — a timeout would not help.
+    Instead, the downloaded bytes are checked against *max_size_mb* after
+    receipt and discarded when the limit is exceeded.
+
+    Returns ``None`` when the download fails or the file exceeds *max_size_mb*.
+    The "Download ESA Model" button falls back to a direct re-run when the ESA
+    file is absent from cache.
+
+    :param analysis: Completed SCIA analysis object.
+    :param max_size_mb: Maximum allowed ESA size in MB.
+    :param progress_prefix: Prefix prepended to every progress message.
+    :param percentage: Optional percentage value for progress messages.
+    :return: ESA bytes when within the size limit, else ``None``.
+    """
+
+    def _report(msg: str) -> None:
+        if progress_message is not None:
+            progress_message(f"{progress_prefix}{msg}", percentage=percentage)
+
+    _report(f"Stage 2: ESA model ophalen uit SCIA worker (max {max_size_mb:.0f} MB)...")
+
+    esa_bytes = _extract_esa_model_for_caching(analysis)
+    if not esa_bytes:
+        return None
+
+    size_mb = len(esa_bytes) / (1024 * 1024)
+    if size_mb > max_size_mb:
+        logger.warning(
+            "ESA model te groot voor cache: %.1f MB > %.0f MB — overgeslagen",
+            size_mb,
+            max_size_mb,
+        )
+        _report(f"Stage 2: ESA model te groot ({size_mb:.1f} MB > {max_size_mb:.0f} MB) — overgeslagen")
+        return None
+
+    _report(f"Stage 2: ESA model voor cache: {size_mb:.1f} MB")
+    return esa_bytes
+
+
 def _extract_content_from_file(file_obj: Any) -> bytes | None:  # noqa: ANN401
     """
     Extract content from a file object, handling different types.
@@ -1883,12 +1932,18 @@ def run_two_stage_scia_analysis(  # noqa: PLR0915
         progress_message(f"{prefix}Stage 2: XML output voor cache: {stage2_xml_size / 1024:.0f} KB", percentage=percentage)
     del xml_output_bytes  # results_stage2["xml_output"] houdt de enige referentie
 
-    esa_model_bytes = _extract_esa_model_for_caching(analysis_stage2)
-    results_stage2["esa_model"] = esa_model_bytes
-    esa_size = len(esa_model_bytes) if esa_model_bytes else 0
-    if esa_size > 0:
-        progress_message(f"{prefix}Stage 2: ESA model voor cache: {esa_size / (1024 * 1024):.1f} MB", percentage=percentage)
-    del esa_model_bytes
+    from app.constants.technical import ENABLE_ESA_MODEL_CACHING, MAX_ESA_CACHE_SIZE_MB
+
+    if ENABLE_ESA_MODEL_CACHING:
+        results_stage2["esa_model"] = _extract_esa_model_with_size_limit(
+            analysis_stage2,
+            max_size_mb=MAX_ESA_CACHE_SIZE_MB,
+            progress_prefix=prefix,
+            percentage=percentage,
+        )
+    else:
+        results_stage2["esa_model"] = None
+        progress_message(f"{prefix}Stage 2: ESA model download overgeslagen (ENABLE_ESA_MODEL_CACHING=False)", percentage=percentage)
 
     # Process stage 2 integration strips
     progress_message(f"{prefix}Stage 2: Verwerken integratiestroken resultaten...", percentage=percentage)
@@ -2073,12 +2128,18 @@ def run_two_stage_scia_analysis_sections_on_plane(  # noqa: PLR0915
         progress_message(f"{prefix}Stage 2: XML output voor cache: {sop_stage2_xml_size / 1024:.0f} KB", percentage=percentage)
     del xml_output_bytes
 
-    sop_esa_model_bytes = _extract_esa_model_for_caching(analysis_stage2)
-    results_stage2["esa_model"] = sop_esa_model_bytes
-    sop_esa_size = len(sop_esa_model_bytes) if sop_esa_model_bytes else 0
-    if sop_esa_size > 0:
-        progress_message(f"{prefix}Stage 2: ESA model voor cache: {sop_esa_size / (1024 * 1024):.1f} MB", percentage=percentage)
-    del sop_esa_model_bytes
+    from app.constants.technical import ENABLE_ESA_MODEL_CACHING, MAX_ESA_CACHE_SIZE_MB
+
+    if ENABLE_ESA_MODEL_CACHING:
+        results_stage2["esa_model"] = _extract_esa_model_with_size_limit(
+            analysis_stage2,
+            max_size_mb=MAX_ESA_CACHE_SIZE_MB,
+            progress_prefix=prefix,
+            percentage=percentage,
+        )
+    else:
+        results_stage2["esa_model"] = None
+        progress_message(f"{prefix}Stage 2: ESA model download overgeslagen (ENABLE_ESA_MODEL_CACHING=False)", percentage=percentage)
 
     # Pre-process sections-on-plane data for caching
     import contextlib

--- a/app/constants/technical.py
+++ b/app/constants/technical.py
@@ -125,3 +125,21 @@ RESULT_OBJECT_SECTIONS_ON_PLANE: str = "Secties op vlak"
 # ENABLE_SECTIONS_ON_PLANE is False so the safe default is integration strips.
 ENABLE_INTEGRATION_STRIPS: bool = False
 ENABLE_SECTIONS_ON_PLANE: bool = True
+
+# ---------------------------------------------------------------------------
+# ESA model caching settings
+# ---------------------------------------------------------------------------
+# Downloading the updated ESA model from the SCIA worker after Stage 2 transfers
+# the full binary .esa file in one blocking call.  If RAM usage exceeds the
+# environment limit the worker crashes and restarts, so a thread timeout offers
+# no benefit.  Instead, the downloaded bytes are discarded when the file exceeds
+# MAX_ESA_CACHE_SIZE_MB to avoid cache overflow.
+#
+# The "Download ESA Model" button falls back to a direct re-run when the ESA
+# file is absent from cache, so skipping large files here has no impact on
+# download functionality.
+ENABLE_ESA_MODEL_CACHING: bool = True
+
+# Maximum allowed ESA file size (in MB) to store in cache.
+# Files exceeding this limit are skipped after download.
+MAX_ESA_CACHE_SIZE_MB: int = 512


### PR DESCRIPTION
- Add _extract_esa_model_with_size_limit() helper that downloads the ESA model and discards it when it exceeds MAX_ESA_CACHE_SIZE_MB (512 MB). A thread timeout is not used: RAM exhaustion crashes the worker anyway.
- Add ENABLE_ESA_MODEL_CACHING and MAX_ESA_CACHE_SIZE_MB constants in app/constants/technical.py for easy tuning.
- Apply the size guard in both Stage 2 paths (integration strips and sections on plane). Stage 1 never downloads the ESA model.
- Download ESA Model button is unaffected; falls back to direct re-run when ESA is absent from cache.

Fixes: app hanging after 'Stage 2: XML output voor cache: X KB'