### PR TITLE
chore: upgrade Python 3.12 → 3.14 (IT security-verplichting)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [`v0.0.34`] - 2026-07-01
+### Changed
+- **Python-versie geüpgraded van 3.12 naar 3.14** (n.a.v. DWO/ICT security-verplichting; oude versies worden per augustus 2026 verwijderd). VIKTOR ondersteunt Python 3.14 sinds de januari-2026 platformrelease.
+  - `viktor.config.toml`: `python_version` `3.12` → `3.14`.
+  - `pyproject.toml`: `requires-python` en mypy `python_version` naar `3.14`.
+  - `requirements.txt` / `requirements_dev.txt`: `viktor` `14.22.0` → `14.29.1` en `pydantic` `2.10.3` → `2.13.4` (beide oude pins ondersteunen geen 3.14). Overige (numpy/scipy/pandas/geopandas/shapely/trimesh) zijn unpinned en lossen automatisch op naar 3.14-compatibele wheels.
+
 ## [`v0.0.33`] - 2026-06-04
 ### Added
 - **Rebar configuration**: Added rebar with diameter of 28 millimeter.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "automatisch-toetsmodel-plaatbruggen"
 description = "A short description of your package"
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 authors = [
     { name = "Your Name", email = "your.email@example.com" }
 ]
@@ -28,7 +28,7 @@ include = ["../automatisch-toetsmodel-plaatbruggen"]
 
 # mypy settings
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.14"
 show_error_codes = true
 pretty = true
 exclude = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-viktor==14.22.0
+viktor==14.29.1
 numpy
 scipy
 pandas
@@ -10,6 +10,6 @@ shapely
 trimesh
 networkx
 docxtpl
-pydantic==2.10.3
+pydantic==2.13.4
 openpyxl
 setuptools<81  # Pin to avoid pkg_resources deprecation warning from docxcompose

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,7 +3,7 @@
 mypy==1.15.0
 ruff==0.11.7
 pytest
-pydantic==2.10.3
+pydantic==2.13.4
 setuptools<81  # Pin to avoid pkg_resources deprecation warning from docxcompose
 
 #mypy type libs

--- a/viktor.config.toml
+++ b/viktor.config.toml
@@ -2,7 +2,7 @@
 app_type = "tree"
 
 # Specify the Python version
-python_version = "3.12"
+python_version = "3.14"
 
 # This should match the name of your app on the VIKTOR platform
 registered_name = "automatisch-toetsmodel-plaatbruggen" 


### PR DESCRIPTION
Closes #387

## Waarom
DWO/ICT verplicht een update naar Python 3.14 (security). Oude versies worden per **augustus 2026** automatisch van de laptop verwijderd. VIKTOR ondersteunt Python 3.14 sinds de januari-2026 platformrelease, dus we kunnen de app-runtime meteen meenemen.

## Wat
- `viktor.config.toml`: `python_version` `3.12` → `3.14`
- `pyproject.toml`: `requires-python` en mypy `python_version` → `3.14`
- `requirements.txt` / `requirements_dev.txt`:
  - `viktor` `14.22.0` → `14.29.1` (14.22 heeft geen 3.14-support; 14.29.1 wel)
  - `pydantic` `2.10.3` → `2.13.4` (2.10 heeft geen 3.14-support; 2.13.4 wel)
- CHANGELOG: `v0.0.34`
- Overige deps (numpy/scipy/pandas/geopandas/shapely/trimesh/…) zijn unpinned → lossen automatisch op naar 3.14-wheels.

## Risico / testfocus voor de reviewer
De config-bump is triviaal; het risico zit in de twee dependency-bumps:
- **viktor 14.22 → 14.29.1** (7 minor versies) — SDK-gedrag verifiëren.
- **pydantic 2.10 → 2.13** — parametrization & validatie verifiëren.

## Nog te verifiëren (kon ik lokaal niet, dev-machine draait nog 3.12)
- [ ] `pip install -r requirements.txt` slaagt op Python 3.14
- [ ] `mypy`, `ruff`, `pytest` groen op 3.14
- [ ] App volledig doorlopen: rekenmodel (SCIA), geometrie, rapportage